### PR TITLE
Removed unnecessary override for get_instance_form_fields which broke plugin compatibility

### DIFF
--- a/class-oik-weight-zone-shipping.php
+++ b/class-oik-weight-zone-shipping.php
@@ -131,16 +131,6 @@ class OIK_Weight_Zone_Shipping extends WC_Shipping_Method {
 	}
 	
 	/**
-	 * Return the instance form fields
-	 *
-	 * @return array of instance form fields
-	 */
-	function get_instance_form_fields() {
-		$this->init_form_fields();
-		return( $this->instance_form_fields );
-	}
-	
-	/**
 	 * Return if the method is available
 	 */
 	


### PR DESCRIPTION
Hello,

thanks for an excellent plugin. However I bumped into an issue where my custom plugin couldn't add additional settings to this plugin. On my use case, I am adding additional textarea to all shipping methods so admin can set custom message that is included on order confirmation email based on shipping method (for example instructions for specific pickup location, etc). 

This change doesn't break any functionality, just makes the plugin also use a hook which lets programmers modify the settings fields - https://github.com/woocommerce/woocommerce/blob/master/includes/abstracts/abstract-wc-shipping-method.php#L455

Regards,
darwell